### PR TITLE
Update inlabs-auto-download-xml.sh

### DIFF
--- a/public/bash/inlabs-auto-download-xml.sh
+++ b/public/bash/inlabs-auto-download-xml.sh
@@ -18,7 +18,7 @@ mes=`date +%m`
 ano=`date +%Y`
 
 ## LOGIN ##
-login="curl --cookie-jar cookies.iakim 'http://inlabs.in.gov.br/logar.php' -H 'origem: 736372697074' --data 'email=$email&password=$senha' --compressed"
+login="curl -k --cookie-jar cookies.iakim 'https://inlabs.in.gov.br/logar.php' -H 'origem: 736372697074' --data 'email=$email&password=$senha' --compressed"
 echo $login > login.sh
 sh login.sh
 rm -rf login.sh
@@ -41,7 +41,7 @@ fi
 ## DOWNLOAD ##
 for secao in $tipo_dou;
 do
-	download="curl --silent -fL -b cookies.iakim 'http://inlabs.in.gov.br/index.php?p=$ano-$mes-$dia&dl=$ano-$mes-$dia-$secao.zip' -H 'origem: 736372697074' --output $ano-$mes-$dia-$secao.zip"
+	download="curl -k --silent -fL -b cookies.iakim 'https://inlabs.in.gov.br/index.php?p=$ano-$mes-$dia&dl=$ano-$mes-$dia-$secao.zip' -H 'origem: 736372697074' --output $ano-$mes-$dia-$secao.zip"
 	echo $download > $ano-$mes-$dia-$secao.sh
 	sh $ano-$mes-$dia-$secao.sh
 	rm -rf $ano-$mes-$dia-$secao.sh


### PR DESCRIPTION
Está retornando o seguinte erro:
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://inlabs.in.gov.br/logar.php">here</a>.</p>
</body></html>
Falha de Autenticação

Aparentemente é necessário utilizar a URL segura HTTPS, porém o curl precisa da cadeia de certificados.

Aí temos duas opções: ou seguir os passos de https://curl.haxx.se/docs/sslcerts.html ou então pedir para que o curl ignore a validação utilizando o parâmetro -k (que foi a solução que adotei)